### PR TITLE
add-promptMix

### DIFF
--- a/README.md
+++ b/README.md
@@ -186,6 +186,7 @@
 | **XpulsAI** | Effortlessly build scalable AI Apps. AutoOps platform for AI & ML | [[Tool]](https://xpuls.ai/) |
 | **Agenta** | Agenta is an open-source LLM developer platform with the tools for prompt management, evaluation, human feedback, and deployment all in one place.  | [[Github]](https://github.com/agenta-ai/agenta) |
 | **Promptotype** | Develop, test, and monitor your LLM { structured } tasks | [[Tool]](https://www.promptotype.io) |
+| **PromptMix** | Drag-and-batch prompt generator with reusable blocks and CSV export | [[Tool]](https://www.promptmix.io/) |
 
 ## Apis
 💻


### PR DESCRIPTION
## Description
PromptMix is a drag-and-drop prompt builder that lets users create reusable blocks and batch-generate up to 1 000 prompts from a CSV. Free plan available; Pro at $5/mo.

## Why is this useful?
Helps marketers and developers produce large prompt datasets quickly without scripting.

## Checklist
- [x] Entry is in alphabetical order
- [x] Uses a descriptive sentence
- [x] Link points to the landing page, not signup