### PR TITLE
Add Neurolink to Tools & Code

### DIFF
--- a/README.md
+++ b/README.md
@@ -174,6 +174,7 @@
 | **Interactive Composition Explorerx** | ICE is a Python library and trace visualizer for language model programs. | [[Github]](https://github.com/oughtinc/ice) |
 | **Haystack** | Open source NLP framework to interact with your data using LLMs and Transformers. | [[Github]](https://github.com/deepset-ai/haystack) |
 | **LangChainx** | Building applications with LLMs through composability | [[Github]](https://github.com/hwchase17/langchain) |
+| **Neurolink** | Multi-provider AI agent framework unifying 12+ providers with workflow orchestration and edge-first deployment. Production-ready with streaming, tool calling, Redis caching, and enterprise features. | [[Github]](https://github.com/juspay/neurolink) |
 | **OpenPrompt** | An Open-Source Framework for Prompt-learning | [[Github]](https://github.com/thunlp/OpenPrompt) |
 | **Prompt Engine** | This repo contains an NPM utility library for creating and maintaining prompts for Large Language Models (LLMs). | [[Github]](https://github.com/microsoft/prompt-engine) |
 | **PromptInject** | PromptInject is a framework that assembles prompts in a modular fashion to provide a quantitative analysis of the robustness of LLMs to adversarial prompt attacks. | [[Github]](https://github.com/agencyenterprise/PromptInject) |


### PR DESCRIPTION
## Adding Neurolink

Adding **Neurolink** to the Tools & Code section. Neurolink is a multi-provider AI agent framework with workflow orchestration that fits alongside tools like LangChain, LlamaIndex, and Haystack.

**What it is**: Production-grade agent framework with workflow orchestration for unified access to 12+ AI providers
**Why it fits**: Developer framework for building multi-agent AI applications
**Production usage**: 15M+ requests/month at Juspay
**Key features**: Multi-agent framework, workflow orchestration, multi-provider support, streaming, tool calling, edge deployment

Repository: https://github.com/juspay/neurolink