### PR TITLE
Add Promptext - Code context optimizer for prompt engineering

### DIFF
--- a/README.md
+++ b/README.md
@@ -179,7 +179,7 @@
 | **PromptInject** | PromptInject is a framework that assembles prompts in a modular fashion to provide a quantitative analysis of the robustness of LLMs to adversarial prompt attacks. | [[Github]](https://github.com/agencyenterprise/PromptInject) |
 | **Prompts AI** | Advanced playground for GPT-3 | [[Github]](https://github.com/sevazhidkov/prompts-ai) |
 | **Prompt Source** | PromptSource is a toolkit for creating, sharing and using natural language prompts. | [[Github]](https://github.com/bigscience-workshop/promptsource) |
-| **Promptext** | Smart code context extractor for AI assistants. Analyzes codebases, filters relevant files with .gitignore support, and provides token-optimized output (PTX, JSONL, TOON, Markdown, XML) with accurate GPT-compatible token counting. Features relevance prioritization and token budget management. | [[Github]](https://github.com/1broseidon/promptext) |
+| **Promptext** | "Extracts and formats code context for AI prompts with token counting" | [[GitHub]](https://github.com/1broseidon/promptext) |
 | **ThoughtSource** | A framework for the science of machine thinking | [[Github]](https://github.com/OpenBioLink/ThoughtSource) |
 | **PROMPTMETHEUS** | One-shot Prompt Engineering Toolkit | [[Tool]](https://promptmetheus.com) |
 | **AI Config** | An Open-Source configuration based framework for building applications with LLMs | [[Github]](https://github.com/lastmile-ai/aiconfig) | 


### PR DESCRIPTION
## Summary
Adding Promptext to the Tools & Code section.

Promptext is a CLI tool for extracting and formatting code context for AI assistants with accurate token counting.

**GitHub:** https://github.com/1broseidon/promptext
**Latest Release:** v0.5.1

The tool helps prompt engineers optimize their prompts by extracting only relevant code context while staying within token limits.