### PR TITLE
Add Price Per Token to Tools section

### DIFF
--- a/README.md
+++ b/README.md
@@ -198,6 +198,7 @@ https://promptslab.github.io
 | **promptfoo** | Test and evaluate LLM applications. Compare prompts and models, red team with adversarial attacks, and integrate into CI/CD. | [[Github]](https://github.com/promptfoo/promptfoo) |
 | **Promptotype** | Develop, test, and monitor your LLM { structured } tasks | [[Tool]](https://www.promptotype.io) |
 | **AI Agent System Prompts Library** | A curated collection of system prompts and tool definitions from production AI coding agents (Claude Code, Gemini CLI, Cline, Aider, Roo Code, Zed, Codex CLI) | [[Github]](https://github.com/tallesborges/agentic-system-prompts) |
+| **Price Per Token** | Compare LLM API pricing across 200+ models with token counters, cost calculators, and benchmark comparisons. | [[Tool]](https://pricepertoken.com/) |
 
 ## Apis
 💻


### PR DESCRIPTION
Adding Price Per Token (https://pricepertoken.com) to the Tools & Code section.

**Why this addition is valuable:**
- Compare LLM API pricing across 300+ models
- Token counters and cost calculators
- Helps developers estimate prompt costs before deployment
- Free to use