### PR TITLE
Add PromptLab to Prompt Management and Testing

### DIFF
--- a/README.md
+++ b/README.md
@@ -251,6 +251,7 @@ These papers established the core concepts that modern prompt engineering builds
 | **PromptInject** | Framework for quantitative analysis of LLM robustness to adversarial prompt attacks. | [GitHub](https://github.com/agencyenterprise/PromptInject) |
 | **LynxPrompt** | Self-hostable platform for managing AI IDE config files (.cursorrules, CLAUDE.md, copilot-instructions.md). Web UI, REST API, CLI, and federated blueprint marketplace for 30+ AI coding assistants. | [GitHub](https://github.com/GeiserX/LynxPrompt) |
 | **flompt** | Visual AI prompt builder that decomposes prompts into 12 semantic blocks (role, context, constraints, examples, etc.) and compiles them into optimized XML. Browser extension for ChatGPT/Claude/Gemini, and MCP server for Claude Code agents. Free, open-source. | [Website](https://flompt.dev) |
+| **PromptLab** | Zero-dependency Python CLI for testing and comparing LLM prompts. Template variables, YAML prompt collections, side-by-side comparison with response time, token usage, and cost metrics. | [GitHub](https://github.com/vesper-astrena/promptlab) |
 
 ### LLM Evaluation Tools
 


### PR DESCRIPTION
Added [PromptLab](https://github.com/vesper-astrena/promptlab) to the Prompt Management and Testing section.

**PromptLab** is a zero-dependency Python CLI for testing and comparing LLM prompts:

- Template variables (`{{variable}}` placeholders)
- YAML prompt collections for side-by-side comparison
- Metrics: response time, token count, estimated cost per call
- Works with OpenAI API

It fits alongside tools like Promptfoo and Better Prompt as a lightweight, terminal-based prompt testing tool.

Happy to adjust the description or placement if needed!