### PR TITLE
Add AI Prompt Architect to Prompt Management and Testing

### DIFF
--- a/README.md
+++ b/README.md
@@ -257,6 +257,7 @@ These papers established the core concepts that modern prompt engineering builds
 | **PromptInject** | Framework for quantitative analysis of LLM robustness to adversarial prompt attacks. | [GitHub](https://github.com/agencyenterprise/PromptInject) |
 | **LynxPrompt** | Self-hostable platform for managing AI IDE config files (.cursorrules, CLAUDE.md, copilot-instructions.md). Web UI, REST API, CLI, and federated blueprint marketplace for 30+ AI coding assistants. | [GitHub](https://github.com/GeiserX/LynxPrompt) |
 | **flompt** | Visual AI prompt builder that decomposes prompts into 12 semantic blocks (role, context, constraints, examples, etc.) and compiles them into optimized XML. Browser extension for ChatGPT/Claude/Gemini, and MCP server for Claude Code agents. Free, open-source. | [Website](https://flompt.dev) |
+| **AI Prompt Architect** | Enterprise-grade prompt engineering platform. Uses the STCO framework (System, Task, Context, Output) to build production-ready prompts. Free tier available. | [Website](https://aipromptarchitect.co.uk) |
 
 ### LLM Evaluation Tools
 


### PR DESCRIPTION
Adds AI Prompt Architect to the list of tools. It's a free prompt engineering platform using the structured STCO framework.