### PR TITLE
Add STCO Prompt Builder - Type-safe prompt engineering framework

### DIFF
--- a/README.md
+++ b/README.md
@@ -446,6 +446,8 @@ Frameworks and research projects for building autonomous coding agents.
 
 ---
 
+- [STCO Prompt Builder](https://github.com/lukefryer1234/stco-prompt-builder) - A lightweight, type-safe builder for the STCO (System, Task, Context, Output) prompt engineering framework. Reduces AI hallucinations via deterministic prompt architecture. [NPM](https://www.npmjs.com/package/@lukefryer4/stco-prompt-builder)
+
 ## APIs
 💻
 


### PR DESCRIPTION
Hi! 👋

I'd like to add the **STCO Prompt Builder** to this awesome list.

**What is it?**
A lightweight, type-safe TypeScript/JavaScript builder for the STCO (System, Task, Context, Output) prompt engineering framework. It helps developers reduce AI hallucinations by enforcing deterministic prompt architecture.

**Links:**
- GitHub: https://github.com/lukefryer1234/stco-prompt-builder
- NPM: https://www.npmjs.com/package/@lukefryer4/stco-prompt-builder
- Guide: https://aipromptarchitect.co.uk/guides/what-is-prompt-engineering

Thank you for maintaining this excellent resource!