### PR TITLE
Add PQS (Prompt Quality Score) to Prompt Management and Testing

### DIFF
--- a/README.md
+++ b/README.md
@@ -257,6 +257,7 @@ These papers established the core concepts that modern prompt engineering builds
 | **PromptInject** | Framework for quantitative analysis of LLM robustness to adversarial prompt attacks. | [GitHub](https://github.com/agencyenterprise/PromptInject) |
 | **LynxPrompt** | Self-hostable platform for managing AI IDE config files (.cursorrules, CLAUDE.md, copilot-instructions.md). Web UI, REST API, CLI, and federated blueprint marketplace for 30+ AI coding assistants. | [GitHub](https://github.com/GeiserX/LynxPrompt) |
 | **flompt** | Visual AI prompt builder that decomposes prompts into 12 semantic blocks (role, context, constraints, examples, etc.) and compiles them into optimized XML. Browser extension for ChatGPT/Claude/Gemini, and MCP server for Claude Code agents. Free, open-source. | [Website](https://flompt.dev) |
+| **PQS (Prompt Quality Score)** | Pre-inference prompt scoring. Grades any prompt on 8 dimensions (clarity, specificity, context, constraints, output format, role definition, examples, CoT structure) using PEEM, RAGAS, MT-Bench, G-Eval, ROUGE. GitHub Action gates prompts in CI; also available as MCP server, Python SDK, REST API. | [GitHub](https://github.com/OnChainAIIntel/pqs-action) |
 
 ### LLM Evaluation Tools
 


### PR DESCRIPTION
## What this adds

[**PQS (Prompt Quality Score)**](https://github.com/OnChainAIIntel/pqs-action) — a pre-inference prompt scoring system, added as a row in the Prompt Management and Testing table.

## Why it fits

PQS is complementary to existing entries in this section. Quick differentiation:

- **Promptfoo** tests *outputs* against assertions (post-inference QA)
- **PQS** scores *inputs* before inference runs (pre-flight quality gate)
- **DSPy / TextGrad** optimize prompts via LLM calls; PQS scores them on structured dimensions without requiring optimization loops

PQS scores any prompt on 8 dimensions using 5 established frameworks (PEEM, RAGAS, MT-Bench, G-Eval, ROUGE). Published on GitHub Marketplace as ["PQS Check"](https://github.com/marketplace/actions/pqs-check) for CI-based gating.

## Ecosystem

- **GitHub Action**: [OnChainAIIntel/pqs-action](https://github.com/OnChainAIIntel/pqs-action) (GitHub Marketplace listed)
- **Python SDK**: [prompt-quality-score](https://pypi.org/project/prompt-quality-score/) on PyPI (CrewAI, LangChain, AutoGen integrations)
- **MCP server**: [pqs-mcp-server](https://www.npmjs.com/package/pqs-mcp-server) on npm (Smithery 88/100, Glama Official)
- **REST API**: [pqs.onchainintel.net](https://pqs.onchainintel.net) — free tier, no signup required

MIT licensed. Happy to rework the description or move to a different section if a better fit exists.
