### PR TITLE
Add AceTagGen — Suno AI structured prompt builder

### DIFF
--- a/README.md
+++ b/README.md
@@ -257,6 +257,7 @@ These papers established the core concepts that modern prompt engineering builds
 | **PromptInject** | Framework for quantitative analysis of LLM robustness to adversarial prompt attacks. | [GitHub](https://github.com/agencyenterprise/PromptInject) |
 | **LynxPrompt** | Self-hostable platform for managing AI IDE config files (.cursorrules, CLAUDE.md, copilot-instructions.md). Web UI, REST API, CLI, and federated blueprint marketplace for 30+ AI coding assistants. | [GitHub](https://github.com/GeiserX/LynxPrompt) |
 | **flompt** | Visual AI prompt builder that decomposes prompts into 12 semantic blocks (role, context, constraints, examples, etc.) and compiles them into optimized XML. Browser extension for ChatGPT/Claude/Gemini, and MCP server for Claude Code agents. Free, open-source. | [Website](https://flompt.dev) |
+| **AceTagGen** | Structured prompt builder specifically for Suno AI music generation. 12-step questionnaire over 3,000+ community-verified tags, built-in quality score validator, and respects Suno's 200-character Style field limit. Free tier, no signup. Includes [public scoring API](https://acetaggen.com/api/suno-score) and [open-source TypeScript library](https://github.com/shaizadok92/suno-prompt-scorer) (MIT) for programmatic prompt evaluation. | [Website](https://acetaggen.com) |
 
 ### LLM Evaluation Tools
 


### PR DESCRIPTION
Adding [AceTagGen](https://acetaggen.com) to the Prompt Management and Testing section.

**What:** Structured prompt builder for Suno AI music generation. Fills a specific gap — while most tools in this list are LLM-focused, Suno has distinct prompting constraints (200-character Style field, specific tag grammar, collision patterns) that general tools don't handle.

**Why it fits this list:**
- 12-step semantic questionnaire (similar to flompt's block-based approach but Suno-specific)
- Built-in prompt quality scorer (4 metrics: length, collisions, specificity, density)
- Open-source TypeScript scoring library: https://github.com/shaizadok92/suno-prompt-scorer
- Public CORS-enabled scoring API: https://acetaggen.com/api/suno-score
- Fully free tier, no signup

**Example scoring API:**
```
GET https://acetaggen.com/api/suno-score?prompt=dark+trap,+808+bass
→ {"total": 94, "breakdown": [...]}
```

Thanks for maintaining the list. Happy to adjust wording.