### PR TITLE
Add promptlint-mcp (static linter for AI prompts)

### DIFF
--- a/README.md
+++ b/README.md
@@ -257,6 +257,7 @@ These papers established the core concepts that modern prompt engineering builds
 | **PromptInject** | Framework for quantitative analysis of LLM robustness to adversarial prompt attacks. | [GitHub](https://github.com/agencyenterprise/PromptInject) |
 | **LynxPrompt** | Self-hostable platform for managing AI IDE config files (.cursorrules, CLAUDE.md, copilot-instructions.md). Web UI, REST API, CLI, and federated blueprint marketplace for 30+ AI coding assistants. | [GitHub](https://github.com/GeiserX/LynxPrompt) |
 | **flompt** | Visual AI prompt builder that decomposes prompts into 12 semantic blocks (role, context, constraints, examples, etc.) and compiles them into optimized XML. Browser extension for ChatGPT/Claude/Gemini, and MCP server for Claude Code agents. Free, open-source. | [Website](https://flompt.dev) |
+| **promptlint-mcp** | Static linter for AI prompts. Catches contradictions, redundancy, ambiguity, oversized examples, and politeness fluff in system prompts and agent instructions. Returns a score, issue list, and sentence-aware trimmed text. CLI + MCP server. Zero network, MIT. | [GitHub](https://github.com/sean-sunagaku/promptlint-mcp) |
 
 ### LLM Evaluation Tools
 


### PR DESCRIPTION
Adds [promptlint-mcp](https://github.com/sean-sunagaku/promptlint-mcp) under **Tools and Code → Prompt Management and Testing**.

It detects contradictions, redundancy, ambiguous pronouns, oversized examples, and politeness fluff in system prompts and agent instructions. Returns a score + issue list + sentence-aware trimmed text. Zero network, zero LLM calls. CLI + MCP server. MIT.

Tools exposed:
- `lint_prompt(text)` - score, issues, trimmed text, token savings
- `trim_prompt(text)` - mechanically trimmed prompt (preserves quoted / backticked / fenced content)

Tested with Claude Code via `claude mcp add`.