### PR TITLE
Add Bernstein to Vibe Coding > CLI-Based Coding Agents

### DIFF
--- a/README.md
+++ b/README.md
@@ -359,6 +359,7 @@ Terminal-native agentic tools that understand your codebase and execute multi-st
 | **Amp** | Sourcegraph's agentic coding tool (Cody successor); works across CLI and IDE. | 🔵 | [Website](https://ampcode.com) |
 | **Junie CLI** | JetBrains' LLM-agnostic coding agent CLI (beta 2026); supports all major model providers. | 🔵 | [Website](https://www.jetbrains.com/junie/) |
 | **Autohand Code CLI** | Self-evolving autonomous terminal coding agent with multi-provider LLM support, 40+ tools, and modular skills system. | 🟢 | [GitHub](https://github.com/autohandai/code-cli) |
+| **Bernstein** | Deterministic Python orchestrator that runs Claude Code, Codex, Gemini CLI and 37 other CLI coding agents in parallel; git-worktree isolation, signed audit log, MCP+A2A support. | 🟢 | [GitHub](https://github.com/sipyourdrink-ltd/bernstein) |
 
 #### AI Code Editors / IDEs
 


### PR DESCRIPTION
Adds Bernstein at the end of the CLI-Based Coding Agents table.

It's terminal-native, agentic, and orchestrates the existing entries (Claude Code, Codex CLI, Gemini CLI, Aider, Goose). Distinct angle: deterministic scheduling — no LLM in the control loop — for running agents in parallel with git-worktree isolation and a signed audit trail. Open source (Apache-2.0). Followed the table format and 🟢 marker for OSS.