### PR TITLE
Red Teaming and Prompt Security: add prompt-injection-shield

### DIFF
--- a/README.md
+++ b/README.md
@@ -320,6 +320,7 @@ These papers established the core concepts that modern prompt engineering builds
 | **Purple Llama (Meta)** | Open-source LLM safety evaluation including CyberSecEval. | [GitHub](https://github.com/meta-llama/PurpleLlama) |
 | **GPTFuzz** | Automated jailbreak template generation achieving >90% success rates. | [GitHub](https://github.com/sherdencooper/GPTFuzz) |
 | **Rebuff** | Open-source tool for detection and prevention of prompt injection. | [GitHub](https://github.com/protectai/rebuff) |
+| **prompt-injection-shield** | Zero-dep JS scanner: instruction overrides, system-prompt impersonation, tool-call hijack, URL-based exfil, secret patterns. Companion to Small-Rule Guardrails preprint. | [GitHub](https://github.com/MukundaKatta/prompt-injection-shield) |
 | **AgentSeal** | "Open-source scanner that runs 150 attack probes to test AI agents for prompt injection and extraction vulnerabilities." | [GitHub](https://github.com/agentseal/agentseal) |
 
 ### MCP (Model Context Protocol)


### PR DESCRIPTION
Adding `prompt-injection-shield` to the Red Teaming and Prompt Security table.

Zero-dependency JavaScript scanner for prompt-injection patterns in untrusted retrieved text. Catches instruction overrides ("ignore previous instructions"), system-prompt impersonation, tool-call hijack, URL-based exfil, and common secret patterns. Returns typed risk reasons so callers can log, gate, or strip lines before they reach the prompt.

MIT, npm `@mukundakatta/prompt-injection-shield`. Companion to a small-rule guardrails preprint on Zenodo (10.5281/zenodo.20057056) and Figshare (10.6084/m9.figshare.32193543).