### PR TITLE
Add agentkit-seo — personal identity context engineering framework

### DIFF
--- a/README.md
+++ b/README.md
@@ -417,6 +417,7 @@ Frameworks and research projects for building autonomous coding agents.
 
 | Name | Description | Type | Link |
 |:-----|:-----------|:----:|:----:|
+| **agentkit-seo** | Context engineering framework for professional identity (GitHub, LinkedIn, CV/ATS, Portfolios). Uses a structured agent-context-file for factual grounding. | 🟢 | [GitHub](https://github.com/agentkit-seo/agentkit-seo) |
 | **OpenHands** | Leading open-source platform for cloud coding agents; consistently top on SWE-bench. Formerly OpenDevin. ~69K+ ⭐ | 🟢 | [GitHub](https://github.com/OpenHands/OpenHands) |
 | **SWE-agent** | Takes a GitHub issue and automatically fixes it using a custom agent-computer interface. [NeurIPS 2024] ~19K+ ⭐ | 🟢 | [GitHub](https://github.com/SWE-agent/SWE-agent) |
 | **Open SWE** | LangChain's async cloud-hosted coding agent framework built on LangGraph with Slack/Linear integration. ~8K+ ⭐ | 🟢 | [GitHub](https://github.com/langchain-ai/open-swe) |


### PR DESCRIPTION
AgentKit SEO applies context engineering to professional discoverability and career-related AI tasks.
Its core concept is the **agent-context-file**: a structured Markdown file containing verified career facts (roles, projects, metrics, links) that an agent loads before making any profile edits. This shift from "prompt engineering" to "context design" prevents hallucinated credentials and generic, non-factual rewrites.

**The framework provides:**
* Structured schemas for career data.
* Platform-specific context rules (GitHub, LinkedIn, CV/ATS, Portfolios).
* A repeatable agentic workflow for auditing and optimizing digital identity.

Install for Claude Code: `npx agentkit-seo install --provider claude-code`

*   **License:** MIT
*   **Repo:** https://github.com/agentkit-seo/agentkit-seo
*   **Website:** https://agentkit-seo.github.io