### PR TITLE
Add 3 production-grade LLM engineering guides to Community section

### DIFF
--- a/README.md
+++ b/README.md
@@ -776,6 +776,9 @@ These models established key concepts but are largely superseded for practical u
 - [DALLE Prompt Book](https://dallery.gallery/the-dalle-2-prompt-book) — Visual guide for text-to-image prompting.
 - [Best 100+ Stable Diffusion Prompts](https://mpost.io/best-100-stable-diffusion-prompts-the-most-beautiful-ai-text-to-image-prompts) — Community-curated image generation prompts.
 - [Vibe Engineering (Manning)](https://www.manning.com/books/vibe-engineering) — Book by Tomasz Lelek & Artur Skowronski on building software through natural language prompts.
+- [Eugene Yan: Patterns for Building LLM-based Systems & Products](https://eugeneyan.com/writing/llm-patterns/) [2023–2025] — Production-grade patterns: evals, RAG, fine-tuning, caching, guardrails, defensive UX. Continuously cited reference for shipping LLM apps.
+- [Chip Huyen: Building LLM Applications for Production](https://huyenchip.com/2023/04/11/llm-engineering.html) [2023] — End-to-end engineering guide covering prompt iteration, cost/latency trade-offs, RAG, fine-tuning, and the production pipeline.
+- [AI-Native Engagement Playbook](https://ai-native-agency.com/playbook) [2026] — Practical playbook for scoping, prompting, and operating production AI builds: 3-phase delivery, prompt management cadence, eval harness setup, and governance controls.
 
 ---
 


### PR DESCRIPTION
Adding three references to the **Community and Independent Guides** subsection. All three round out coverage of the engineering side of prompting — production patterns, eval-driven iteration, and operating cadence — which is somewhat thinner than the pure-prompting coverage in the current list.

- **[Eugene Yan: Patterns for Building LLM-based Systems & Products](https://eugeneyan.com/writing/llm-patterns/)** — Production patterns reference. Heavily cited in the LLM engineering community.
- **[Chip Huyen: Building LLM Applications for Production](https://huyenchip.com/2023/04/11/llm-engineering.html)** — End-to-end engineering guide, still one of the cleanest treatments of the production pipeline.
- **[AI-Native Engagement Playbook](https://ai-native-agency.com/playbook)** — Practical playbook for scoping, prompting cadence, and operating AI builds. Complements the technique-heavy content already in the list with a delivery-and-controls perspective.

All entries follow the existing markdown format. Year tags added where applicable.