### PR TITLE
Add CLAWVR to Other Notable Repositories

### DIFF
--- a/README.md
+++ b/README.md
@@ -443,6 +443,7 @@ Frameworks and research projects for building autonomous coding agents.
 | **Price Per Token** | Compare LLM API pricing across 200+ models. | [Website](https://pricepertoken.com/) |
 | **OpenPaw** | CLI tool (`npx pawmode`) that turns Claude Code into a personal assistant by generating system prompts (CLAUDE.md + SOUL.md) with personality, memory, and 38 skill routers. | [GitHub](https://github.com/daxaur/openpaw) |
 | **Think Better** | Open-source CLI that permanently injects 10 structured decision frameworks (MECE, Issue Trees, Pre-Mortems) and 12 cognitive bias detectors into AI assistant prompts. Go, MIT. | [GitHub](https://github.com/HoangTheQuyen/think-better) |
+| **CLAWVR** | Generates a custom AI Operating System for a small business from a 3-minute intake — a master Claude system prompt plus 18 industry-specific superprompts (insurance verification, patient reactivation, bid follow-ups, etc.) pre-loaded with the owner's industry, tools, and team context. | [Website](https://clawvr.com/) |
 
 ---
 


### PR DESCRIPTION
## What this adds

A single-row entry for [CLAWVR](https://clawvr.com/) in the **Other Notable Repositories** table under the **Tools and Code** section.

## Why it fits this list

CLAWVR is a prompt-engineering productization for small business owners: a 3-minute intake generates a master Claude system prompt plus 18 industry-specific superprompts pre-loaded with the owner's industry, software stack, team size, and customer profile. The prompts paste directly into the owner's own Claude (or ChatGPT/Gemini) account.

It's adjacent in spirit to existing entries in this section:
- **OpenPaw** (CLI that generates CLAUDE.md/SOUL.md) — same idea but for individuals using Claude Code
- **Think Better** (CLI that injects decision frameworks into AI prompts) — same idea but for structured reasoning
- **Price Per Token** — a Website link, demonstrating non-GitHub entries are accepted in this table

CLAWVR is the SMB / business-operator equivalent — it productionizes the master-system-prompt pattern for non-technical small business owners.

## Format

- Single new row appended to the existing **Other Notable Repositories** table
- Pipe-formatted Markdown matching the existing column widths
- `[Website](https://clawvr.com/)` link (CLAWVR's prompts are proprietary, not hosted on GitHub)
- One sentence, ends with a period, no trailing whitespace

Happy to revise the wording, the section placement, or drop the entry entirely if it's not a fit.