### PR TITLE
Add Promptra to Other Notable Providers

### DIFF
--- a/README.md
+++ b/README.md
@@ -505,6 +505,7 @@ Available on 25+ cloud partners, Hugging Face, and inference APIs. [Llama](https
 | **Groq** | LPU hardware with ~300+ tokens/sec inference. | [Website](https://groq.com) |
 | **Fireworks AI** | Fast inference with HIPAA + SOC2 compliance. | [Website](https://fireworks.ai) |
 | **OpenRouter** | Unified API for 300+ models from all providers. | [Website](https://openrouter.ai) |
+| **Promptra** | OpenAI-compatible gateway aggregating Claude, GPT, Gemini, DeepSeek and other LLMs. Russian-market focus with ruble billing. | [Website](https://promptra.ru) |
 | **Cerebras** | Wafer-scale chips with best total response time. | [Website](https://cerebras.ai) |
 | **Perplexity AI** | Search-augmented API with citations. | [Website](https://perplexity.ai) |
 | **Amazon Bedrock** | Managed multi-model service with Claude, Llama, Mistral, Cohere. | [Website](https://aws.amazon.com/bedrock/) |


### PR DESCRIPTION
## What this adds

Adds **Promptra** as a new row in the *APIs > Other Notable Providers* table. The entry is placed directly under OpenRouter, since the two services share the same model (unified API across multiple LLM vendors).

## Why it fits this list

The list already curates LLM API providers and explicitly includes aggregators (OpenRouter) alongside primary providers (Mistral, DeepSeek, Cohere, etc.). Promptra is the same category — an OpenAI-compatible gateway over Claude, GPT, Gemini, DeepSeek and other LLMs.

The differentiating context I noted in the description is the Russian-market focus (ruble billing) — that scopes the entry honestly rather than overclaiming feature parity with OpenRouter on global reach.

## Format

- Single table row, same shape as the rest of *Other Notable Providers*
- Placed adjacent to the closest analog (OpenRouter) rather than alphabetically, matching the existing ordering of the table (which groups by topic/popularity, not alphabet)
- Description kept neutral and factual; no marketing adjectives

## Links

- Site: https://promptra.ru/
- Open source: https://github.com/solsemssa-alt/promptra-web