### PR TITLE
Add Ariadne Loop

### DIFF
--- a/README.md
+++ b/README.md
@@ -257,6 +257,7 @@ These papers established the core concepts that modern prompt engineering builds
 | **PromptInject** | Framework for quantitative analysis of LLM robustness to adversarial prompt attacks. | [GitHub](https://github.com/agencyenterprise/PromptInject) |
 | **LynxPrompt** | Self-hostable platform for managing AI IDE config files (.cursorrules, CLAUDE.md, copilot-instructions.md). Web UI, REST API, CLI, and federated blueprint marketplace for 30+ AI coding assistants. | [GitHub](https://github.com/GeiserX/LynxPrompt) |
 | **flompt** | Visual AI prompt builder that decomposes prompts into 12 semantic blocks (role, context, constraints, examples, etc.) and compiles them into optimized XML. Browser extension for ChatGPT/Claude/Gemini, and MCP server for Claude Code agents. Free, open-source. | [Website](https://flompt.dev) |
+| **Ariadne Loop** | Local-first Loop Engineering workbench for turning rough project context into verifiable agent specs, verifier gates, rollback rules, and JSON report contracts. | [GitHub](https://github.com/zhangzeyu99-web/ariadne-loop) |
 
 ### LLM Evaluation Tools
 


### PR DESCRIPTION
## Summary
- Add Ariadne Loop to Prompt Management and Testing.
- It is a local-first Loop Engineering workbench for turning rough project context into verifiable agent specs, verifier gates, rollback rules, and JSON report contracts.

## Validation
- Ran git diff --check.
- Installed from GitHub and verified ariadne-loop --version.
- Ran ariadne-loop quickstart and verified agent-packet.md was generated.