### PR TITLE
Add DecisionMap

### DIFF
--- a/README.md
+++ b/README.md
@@ -443,6 +443,7 @@ Frameworks and research projects for building autonomous coding agents.
 | **Price Per Token** | Compare LLM API pricing across 200+ models. | [Website](https://pricepertoken.com/) |
 | **OpenPaw** | CLI tool (`npx pawmode`) that turns Claude Code into a personal assistant by generating system prompts (CLAUDE.md + SOUL.md) with personality, memory, and 38 skill routers. | [GitHub](https://github.com/daxaur/openpaw) |
 | **Think Better** | Open-source CLI that permanently injects 10 structured decision frameworks (MECE, Issue Trees, Pre-Mortems) and 12 cognitive bias detectors into AI assistant prompts. Go, MIT. | [GitHub](https://github.com/HoangTheQuyen/think-better) |
+| **DecisionMap** | Practical AI-assisted protocol and prompt toolkit for turning complex business, product, and market decisions into visible strategy maps. | [GitHub](https://github.com/markoblogo/decision-map) |
 
 ---
 


### PR DESCRIPTION
## Summary
- add DecisionMap to other notable repositories

## Why it fits
DecisionMap is an open-source AI-assisted decision protocol and prompt toolkit for structured business, product, and market strategy mapping.

## LLM disclosure
I used Codex as an editing assistant and reviewed the final diff before submitting.
