### PR TITLE
Add Presentation Design Prompts to Other Notable Repositories

### DIFF
--- a/README.md
+++ b/README.md
@@ -443,6 +443,7 @@ Frameworks and research projects for building autonomous coding agents.
 | **Price Per Token** | Compare LLM API pricing across 200+ models. | [Website](https://pricepertoken.com/) |
 | **OpenPaw** | CLI tool (`npx pawmode`) that turns Claude Code into a personal assistant by generating system prompts (CLAUDE.md + SOUL.md) with personality, memory, and 38 skill routers. | [GitHub](https://github.com/daxaur/openpaw) |
 | **Think Better** | Open-source CLI that permanently injects 10 structured decision frameworks (MECE, Issue Trees, Pre-Mortems) and 12 cognitive bias detectors into AI assistant prompts. Go, MIT. | [GitHub](https://github.com/HoangTheQuyen/think-better) |
+| **Presentation Design Prompts** | 56 free slide-design prompts for ChatGPT/Claude. Each one is a full deck theme with a pinned color palette, named Google Fonts, and layout rules, so generated slides stay consistent. MIT. | [GitHub](https://github.com/SlideSpeak/presentation-design-prompts) |
 
 ---
 


### PR DESCRIPTION
Thanks for keeping this list current. I've sent people here before.

I maintain an open-source collection of slide-design prompts for ChatGPT and Claude, and I think it fits under Other Notable Repositories alongside the other domain-specific prompt collections.

Each entry is one prompt that carries a full design system: a color palette pinned to hex values, named Google Fonts, and layout rules. The model stops producing clip-art decks and every slide matches. 56 themes, MIT licensed.

Repo: https://github.com/SlideSpeak/presentation-design-prompts

I added one row in this PR. Close it or reword it if it's not a fit. Thanks for taking a look.
