### PR TITLE
Add NotFair to the MCP section (open-source Claude Code marketing skills)

### DIFF
--- a/README.md
+++ b/README.md
@@ -336,6 +336,7 @@ MCP is an open standard developed by Anthropic (Nov 2024, donated to Linux Found
 | **Context7** | MCP server providing version-specific documentation to reduce code hallucination. | [GitHub](https://github.com/upstash/context7) |
 | **GitMCP** | Creates remote MCP servers for any GitHub repo by changing the domain. | [Website](https://gitmcp.io/) |
 | **MCP Inspector** | Visual testing tool for MCP server development. | [GitHub](https://github.com/modelcontextprotocol/inspector) |
+| **NotFair** | Open-source Claude Code skills for SEO, GEO, Google Ads, and Meta Ads ([seo](https://github.com/nowork-studio/NotFair/tree/main/seo), [google-ads](https://github.com/nowork-studio/NotFair/tree/main/google-ads), [meta-ads](https://github.com/nowork-studio/NotFair/tree/main/meta-ads)); connects to live data through the Google Ads MCP, Meta Ads MCP, Google Search Console MCP, and Google Analytics (GA4) MCP. MIT. ~2.9K+ ⭐ | [GitHub](https://github.com/nowork-studio/NotFair) |
 
 ### Vibe Coding and AI Coding Assistants
 


### PR DESCRIPTION
Hi, and thanks for maintaining this list — the MCP section is a genuinely useful map of the ecosystem.

I'd like to suggest adding **NotFair** ([nowork-studio/NotFair](https://github.com/nowork-studio/NotFair)), an open-source (MIT, ~2.9k stars) set of Claude Code skills for marketing work: SEO and GEO (site analysis, keyword research, meta tags, schema markup, content writing), Google Ads, and Meta Ads.

I think it fits the MCP section because it's built entirely around MCP: it connects to live data through the Google Ads MCP, Meta Ads MCP, Google Search Console MCP, and Google Analytics (GA4) MCP. Most MCP entries here are infrastructure or dev-side servers, so this adds a concrete domain-specific example of MCP clients in use.

Happy to reword the description, trim it, or move it to a different section if you feel it sits better elsewhere — just let me know.