### PR TITLE
Add AgentMark to Prompt Management and Testing

### DIFF
--- a/README.md
+++ b/README.md
@@ -257,6 +257,7 @@ These papers established the core concepts that modern prompt engineering builds
 | **PromptInject** | Framework for quantitative analysis of LLM robustness to adversarial prompt attacks. | [GitHub](https://github.com/agencyenterprise/PromptInject) |
 | **LynxPrompt** | Self-hostable platform for managing AI IDE config files (.cursorrules, CLAUDE.md, copilot-instructions.md). Web UI, REST API, CLI, and federated blueprint marketplace for 30+ AI coding assistants. | [GitHub](https://github.com/GeiserX/LynxPrompt) |
 | **flompt** | Visual AI prompt builder that decomposes prompts into 12 semantic blocks (role, context, constraints, examples, etc.) and compiles them into optimized XML. Browser extension for ChatGPT/Claude/Gemini, and MCP server for Claude Code agents. Free, open-source. | [Website](https://flompt.dev) |
+| **AgentMark** | Open-source, Git-native platform for prompt management: author prompts as Markdown, version them in your repo, and evaluate in CI. | [GitHub](https://github.com/agentmark-ai/agentmark) |
 
 ### LLM Evaluation Tools
 


### PR DESCRIPTION
Adds **AgentMark** to **Tools and Code → Prompt Management and Testing**.

[AgentMark](https://github.com/agentmark-ai/agentmark) is an open-source, Git-native platform for prompt management: author prompts as Markdown, version them in your repo, and evaluate in CI — a natural fit alongside Agenta and PromptLayer in this table.

- Single row appended to the existing table, matching the `| Name | Description | Link |` format
- Live GitHub link