### PR TITLE
Add compare-prompts to LLM tools list in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -257,6 +257,7 @@ These papers established the core concepts that modern prompt engineering builds
 | **PromptInject** | Framework for quantitative analysis of LLM robustness to adversarial prompt attacks. | [GitHub](https://github.com/agencyenterprise/PromptInject) |
 | **LynxPrompt** | Self-hostable platform for managing AI IDE config files (.cursorrules, CLAUDE.md, copilot-instructions.md). Web UI, REST API, CLI, and federated blueprint marketplace for 30+ AI coding assistants. | [GitHub](https://github.com/GeiserX/LynxPrompt) |
 | **flompt** | Visual AI prompt builder that decomposes prompts into 12 semantic blocks (role, context, constraints, examples, etc.) and compiles them into optimized XML. Browser extension for ChatGPT/Claude/Gemini, and MCP server for Claude Code agents. Free, open-source. | [Website](https://flompt.dev) |
+| **compare-prompts** | Offline, zero-config CLI for behavioral LLM prompt evaluation. Measures tone, refusal rate, reading level, cost, and token usage side by side. | [GitHub](https://github.com/OmarMashal0/compare-prompts) |
 
 ### LLM Evaluation Tools
 


### PR DESCRIPTION
hi, adding compare-prompts, a lightweight zero-dependency CLI for behavioral LLM prompt evaluation. Thought it would be a good fit for the tools section. thanks for maintaining this list :)