### PR TITLE
Add Suno Prompt Lab

### DIFF
--- a/README.md
+++ b/README.md
@@ -257,6 +257,7 @@ These papers established the core concepts that modern prompt engineering builds
 | **PromptInject** | Framework for quantitative analysis of LLM robustness to adversarial prompt attacks. | [GitHub](https://github.com/agencyenterprise/PromptInject) |
 | **LynxPrompt** | Self-hostable platform for managing AI IDE config files (.cursorrules, CLAUDE.md, copilot-instructions.md). Web UI, REST API, CLI, and federated blueprint marketplace for 30+ AI coding assistants. | [GitHub](https://github.com/GeiserX/LynxPrompt) |
 | **flompt** | Visual AI prompt builder that decomposes prompts into 12 semantic blocks (role, context, constraints, examples, etc.) and compiles them into optimized XML. Browser extension for ChatGPT/Claude/Gemini, and MCP server for Claude Code agents. Free, open-source. | [Website](https://flompt.dev) |
+| **Suno Prompt Lab** | Browser-based workspace for drafting and refining text prompts for AI music generation workflows such as Suno and Udio. | [Website](https://suno-prompt-lab.vercel.app/) |
 
 ### LLM Evaluation Tools
 


### PR DESCRIPTION
Adds Suno Prompt Lab to the prompt management and testing tools section.\n\nIt is a browser-based workspace for drafting and refining prompts for AI music generation workflows.