### PR TITLE
Add Tura to CLI-based coding agents

### DIFF
--- a/README.md
+++ b/README.md
@@ -355,6 +355,7 @@ Terminal-native agentic tools that understand your codebase and execute multi-st
 | **OpenCode** | Powerful open-source AI coding agent with beautiful TUI; supports nearly all AI model providers. ~120K+ ⭐ | 🟢 | [GitHub](https://github.com/opencode-ai/opencode) |
 | **Goose** | Extensible open-source AI agent from Block (Square/Cash App); installs, executes, edits, and tests with any LLM. ~29K+ ⭐ | 🟢 | [GitHub](https://github.com/block/goose) |
 | **Crush** | Glamorous agentic coding agent from Charmbracelet with multi-model support, LSP integration, and beautiful terminal UI. ~9K+ ⭐ | 🟢 | [GitHub](https://github.com/charmbracelet/crush) |
+| **Tura** | Open-source, local-first coding agent with an interactive TUI, scriptable CLI, persistent sessions, and multi-provider model routing. | 🟢 | [GitHub](https://github.com/Tura-AI/tura) |
 | **Amazon Q Developer CLI** | Agentic chat experience in terminal from AWS; transitioning to Kiro CLI. | 🟣 | [GitHub](https://github.com/aws/amazon-q-developer-cli) |
 | **Amp** | Sourcegraph's agentic coding tool (Cody successor); works across CLI and IDE. | 🔵 | [Website](https://ampcode.com) |
 | **Junie CLI** | JetBrains' LLM-agnostic coding agent CLI (beta 2026); supports all major model providers. | 🔵 | [Website](https://www.jetbrains.com/junie/) |

--- a/README.md
+++ b/README.md
@@ -355,7 +355,7 @@ Terminal-native agentic tools that understand your codebase and execute multi-st
 | **OpenCode** | Powerful open-source AI coding agent with beautiful TUI; supports nearly all AI model providers. ~120K+ ⭐ | 🟢 | [GitHub](https://github.com/opencode-ai/opencode) |
 | **Goose** | Extensible open-source AI agent from Block (Square/Cash App); installs, executes, edits, and tests with any LLM. ~29K+ ⭐ | 🟢 | [GitHub](https://github.com/block/goose) |
 | **Crush** | Glamorous agentic coding agent from Charmbracelet with multi-model support, LSP integration, and beautiful terminal UI. ~9K+ ⭐ | 🟢 | [GitHub](https://github.com/charmbracelet/crush) |
-| **Tura** | Open-source, local-first coding agent with an interactive TUI, scriptable CLI, persistent sessions, and multi-provider model routing. | 🟢 | [GitHub](https://github.com/Tura-AI/tura) |
+| **Tura** | Tura is a local, open-source coding agent for developers who are tired of vague skill claims, token-saving extensions with no evidence, and agents that change a repository before understanding it. | 🟢 | [GitHub](https://github.com/Tura-AI/tura) |
 | **Amazon Q Developer CLI** | Agentic chat experience in terminal from AWS; transitioning to Kiro CLI. | 🟣 | [GitHub](https://github.com/aws/amazon-q-developer-cli) |
 | **Amp** | Sourcegraph's agentic coding tool (Cody successor); works across CLI and IDE. | 🔵 | [Website](https://ampcode.com) |
 | **Junie CLI** | JetBrains' LLM-agnostic coding agent CLI (beta 2026); supports all major model providers. | 🔵 | [Website](https://www.jetbrains.com/junie/) |


### PR DESCRIPTION
## Summary

Adds [Tura](https://github.com/Tura-AI/tura) to the CLI-Based Coding Agents table.

## Why it fits

- Open-source, terminal-native coding agent with both an interactive TUI and a scriptable CLI.
- Supports persistent sessions and routing across multiple model providers.
- The project is actively maintained, with its latest GitHub update on July 15, 2026.
- I tested the current v0.1.33 CLI locally and kept the entry to the list's one-line table format.

## Validation

- `git diff --check`
- Project link returns HTTP 200
- One README row added; no unrelated changes

Disclosure: I am affiliated with Tura. AI assistance was used to research the contribution rules and prepare this one-line addition.