### PR TITLE
Add Ecommerce Prompts to Other Notable Repositories

### DIFF
--- a/README.md
+++ b/README.md
@@ -443,6 +443,7 @@ Frameworks and research projects for building autonomous coding agents.
 | **Price Per Token** | Compare LLM API pricing across 200+ models. | [Website](https://pricepertoken.com/) |
 | **OpenPaw** | CLI tool (`npx pawmode`) that turns Claude Code into a personal assistant by generating system prompts (CLAUDE.md + SOUL.md) with personality, memory, and 38 skill routers. | [GitHub](https://github.com/daxaur/openpaw) |
 | **Think Better** | Open-source CLI that permanently injects 10 structured decision frameworks (MECE, Issue Trees, Pre-Mortems) and 12 cognitive bias detectors into AI assistant prompts. Go, MIT. | [GitHub](https://github.com/HoangTheQuyen/think-better) |
+| **Ecommerce Prompts (xpay)** | Free, copy-and-run ChatGPT prompt library for online stores — 924 prompts across 43 product categories and 10 marketing tasks. MIT. | [GitHub](https://github.com/xpaysh/ecommerce-prompts-mcp) |
 
 ---
 


### PR DESCRIPTION
Adds one row to **Other Notable Repositories**: [Ecommerce Prompts](https://github.com/xpaysh/ecommerce-prompts-mcp) — an open-source (MIT) library of 924 copy-and-run ChatGPT prompts for online stores + an open MCP server. Matched the existing table format.

Disclosure: I work on xpay, which publishes this free prompt library.