### PR TITLE
Add HalaGPT Academy — Arabic prompt library and prompt engineering course

### DIFF
--- a/README.md
+++ b/README.md
@@ -776,6 +776,7 @@ These models established key concepts but are largely superseded for practical u
 - [DALLE Prompt Book](https://dallery.gallery/the-dalle-2-prompt-book) — Visual guide for text-to-image prompting.
 - [Best 100+ Stable Diffusion Prompts](https://mpost.io/best-100-stable-diffusion-prompts-the-most-beautiful-ai-text-to-image-prompts) — Community-curated image generation prompts.
 - [Vibe Engineering (Manning)](https://www.manning.com/books/vibe-engineering) — Book by Tomasz Lelek & Artur Skowronski on building software through natural language prompts.
+- [HalaGPT Academy — Arabic](https://hala.academy/prompts) — Arabic-language prompt library and free course on prompt engineering: 53 ready-to-use Arabic prompts for ChatGPT and Gemini across writing, business, content and study, plus a 54-term AI glossary in plain Arabic.
 
 ---
 


### PR DESCRIPTION
Adds one entry to **Tutorials and Guides → Community and Independent Guides**.

[HalaGPT Academy](https://hala.academy) is a free Arabic-language resource for prompt engineering:

- a library of **53 ready-to-use Arabic prompts** for ChatGPT and Gemini, grouped by use case (writing, business, content, images, study)
- a free course on prompt engineering taught in Arabic
- a **54-term AI glossary** giving each term in plain Arabic alongside its English equivalent

**Why this belongs here:** the list currently has no Arabic-language entry. There is already precedent for language-specific prompt resources in this space (the Chinese `awesome-prompt-engineering-ZH-CN` fork exists for the same reason), and Arabic prompt-engineering material is genuinely scarce for a language with 400M+ speakers.

Everything is free and readable without an account. Happy to adjust the wording or move it to a different section if you'd prefer.