### PR TITLE
Add Graph Engineering on Research to Other Notable Repositories

### DIFF
--- a/README.md
+++ b/README.md
@@ -443,6 +443,7 @@ Frameworks and research projects for building autonomous coding agents.
 | **Price Per Token** | Compare LLM API pricing across 200+ models. | [Website](https://pricepertoken.com/) |
 | **OpenPaw** | CLI tool (`npx pawmode`) that turns Claude Code into a personal assistant by generating system prompts (CLAUDE.md + SOUL.md) with personality, memory, and 38 skill routers. | [GitHub](https://github.com/daxaur/openpaw) |
 | **Think Better** | Open-source CLI that permanently injects 10 structured decision frameworks (MECE, Issue Trees, Pre-Mortems) and 12 cognitive bias detectors into AI assistant prompts. Go, MIT. | [GitHub](https://github.com/HoangTheQuyen/think-better) |
+| **Graph Engineering on Research** | Copy-paste multi-agent prompt templates (also a Claude Code plugin): parallel diamond research, adversarial review, Delphi consultant roundtables, self-dispatching issue trees. EN + 繁中, MIT. | [GitHub](https://github.com/InjayTseng/graph-engineering-on-research) |
 
 ---
 


### PR DESCRIPTION
Adds one row to Tools and Code → Other Notable Repositories:

**Graph Engineering on Research** — https://github.com/InjayTseng/graph-engineering-on-research

Copy-paste multi-agent prompt templates that run research as a graph instead of a sequential pipeline: parallel search angles with adversarial verification (diamond research), isolated attackers against finished documents (adversarial review), two-round anonymous Delphi panels (consultant roundtable), and MECE issue trees that dispatch their own leaves. Every template is a self-contained paste block for any agent or chat interface, and the repo also installs as a Claude Code plugin (six slash commands). English + Traditional Chinese, MIT licensed, with a companion article documenting field results (313 agents, 16–40% claim-rejection rates).

Disclosure: I'm the author. The methods are pre-LLM classics (Delphi, Devil's Advocacy, ACH, Minto's issue trees) adapted into agent prompts, and each template has been tested in real runs — one verbatim transcript is included in the repo.

🤖 Generated with [Claude Code](https://claude.com/claude-code)