### PR TITLE
Add tokensift to Prompt Management and Testing

### DIFF
--- a/README.md
+++ b/README.md
@@ -257,6 +257,7 @@ These papers established the core concepts that modern prompt engineering builds
 | **PromptInject** | Framework for quantitative analysis of LLM robustness to adversarial prompt attacks. | [GitHub](https://github.com/agencyenterprise/PromptInject) |
 | **LynxPrompt** | Self-hostable platform for managing AI IDE config files (.cursorrules, CLAUDE.md, copilot-instructions.md). Web UI, REST API, CLI, and federated blueprint marketplace for 30+ AI coding assistants. | [GitHub](https://github.com/GeiserX/LynxPrompt) |
 | **flompt** | Visual AI prompt builder that decomposes prompts into 12 semantic blocks (role, context, constraints, examples, etc.) and compiles them into optimized XML. Browser extension for ChatGPT/Claude/Gemini, and MCP server for Claude Code agents. Free, open-source. | [Website](https://flompt.dev) |
+| **tokensift** | npm library and CLI for token-efficiency linting of LLM prompts and payloads: exact BPE token counts for OpenAI, calibrated estimates for Claude, real dollar cost per finding, CI-ready. | [GitHub](https://github.com/ritenv/tokensift) |
 
 ### LLM Evaluation Tools
 


### PR DESCRIPTION
Adds tokensift, an npm library and CLI for token-efficiency linting of LLM prompts and payloads. It tokenizes with the actual provider encoder (exact BPE counts for OpenAI, calibrated estimates for Claude) and flags waste like UUIDs, base64 blobs, pretty-printed JSON, and repeated blocks, with real dollar cost per finding. Works as a library, a CLI, and CI check.

GitHub: https://github.com/ritenv/tokensift
npm: https://www.npmjs.com/package/tokensift