### PR TITLE
Add PromptAI 360 to Prompt Engineering Tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -249,6 +249,7 @@ These papers established the core concepts that modern prompt engineering builds
 | **Promptotype** | Platform for developing, testing, and managing structured LLM prompts. | [Website](https://www.promptotype.io) |
 | **PromptPanda** | AI-powered prompt management system for streamlining prompt workflows. | [Website](https://promptpanda.io) |
 | **Promptimize AI** | Browser extension to automatically improve user prompts for any AI model. | [Website](https://promptimize.ai) |
+| **PromptAI 360** | One-click prompt enhancer that restructures rough prompts with role, context, constraints, and output format. Chrome extension for ChatGPT/Claude/Gemini/Perplexity, plus a macOS global-hotkey app for Claude Code and Cursor. | [Website](https://www.promptai360.com) |
 | **PROMPTMETHEUS** | Web-based "Prompt Engineering IDE" for iteratively creating and running prompts. | [Website](https://promptmetheus.com) |
 | **Better Prompt** | Test suite for LLM prompts before pushing to production. | [GitHub](https://github.com/krrishdholakia/betterprompt) |
 | **OpenPrompt** | Open-source framework for prompt-learning research. | [GitHub](https://github.com/thunlp/OpenPrompt) |


### PR DESCRIPTION
Adds [PromptAI 360](https://www.promptai360.com) to the Prompt Engineering Tools table, next to the other prompt-enhancement browser extensions (Promptimize AI, flompt).

PromptAI 360 is a one-click prompt enhancer: it restructures a rough prompt into a structured one (role, context, constraints, output format). It ships as a Chrome extension that works inside ChatGPT, Claude, Gemini, and Perplexity, and a macOS app with a global hotkey that works in Claude Code and Cursor. There's a no-signup live demo at https://www.promptai360.com/demo for quick evaluation.

Entry follows the existing table format. Thanks for maintaining the list!