### PR TITLE
Add OpenH3-IR to Tools and Code

### DIFF
--- a/README.md
+++ b/README.md
@@ -305,7 +305,7 @@ These papers established the core concepts that modern prompt engineering builds
 | **DSPy** | Multiple optimizers (MIPROv2, BootstrapFewShot, COPRO) for automatic prompt tuning. ~22K+ ⭐ | [GitHub](https://github.com/stanfordnlp/dspy) |
 | **TextGrad** | Automatic differentiation via text (Stanford). ~2K+ ⭐ | [GitHub](https://github.com/zou-group/textgrad) |
 | **OPRO** | Google DeepMind's optimization by prompting. | [GitHub](https://github.com/google-deepmind/opro) |
-| **OpenH3-IR** | H3 wants a long Context-IR prompt document, and MiniMax kept the part that writes it on their servers. An open take you run yourself: type a sentence, get that document, checked and fixed before it renders. Command line, HTTP, or its own ComfyUI nodes. | [GitHub](https://github.com/ruashots/open-h3-ir) |
+| **OpenH3-IR** | Writes MiniMax H3's Context-IR document from one sentence, then checks and fixes it. Not a prompt rewriter: it follows H3's own published format. Uses any OpenAI-compatible model you already run. | [GitHub](https://github.com/ruashots/open-h3-ir) |
 
 ### Red Teaming and Prompt Security
 

--- a/README.md
+++ b/README.md
@@ -305,6 +305,7 @@ These papers established the core concepts that modern prompt engineering builds
 | **DSPy** | Multiple optimizers (MIPROv2, BootstrapFewShot, COPRO) for automatic prompt tuning. ~22K+ ⭐ | [GitHub](https://github.com/stanfordnlp/dspy) |
 | **TextGrad** | Automatic differentiation via text (Stanford). ~2K+ ⭐ | [GitHub](https://github.com/zou-group/textgrad) |
 | **OPRO** | Google DeepMind's optimization by prompting. | [GitHub](https://github.com/google-deepmind/opro) |
+| **OpenH3-IR** | H3 wants a long Context-IR prompt document, and MiniMax kept the part that writes it on their servers. An open take you run yourself: type a sentence, get that document, checked and fixed before it renders. Command line, HTTP, or its own ComfyUI nodes. | [GitHub](https://github.com/ruashots/open-h3-ir) |
 
 ### Red Teaming and Prompt Security
 


### PR DESCRIPTION
Adds OpenH3-IR, an open take on the part that writes the long Context-IR document MiniMax H3 expects. Apache-2.0: https://github.com/ruashots/open-h3-ir

MiniMax published that format and finished examples of it, and kept the part that writes it on their own servers. So this is not a prompt enhancer and there is no wording to improve: it writes the document itself, with the named sections in a fixed order, numbered picture labels, a length the model can actually render, per-shot cut times, and sound described separately.

Why it fits this list. The checking is the point. It checks its own output against a fixed set of named checks, fixes what is mechanical, and says what it could not fix rather than shipping something broken. MiniMax's own published examples are in the test set and have to pass clean, since a check that fires on the spec's own artifact is a wrong check, and fifteen deliberately broken copies of one of them each have to fail on the check that defect earns. A scoring run compares a change against a stored baseline, which catches an edit that improves one prompt and wrecks another. 22 checks and 901 tests run with no model, no GPU and no network.

What it needs to run: an OpenAI-compatible model you already have, which is where the writing happens, and nothing else. No cloud account, and no GPU of its own.

Two ways to use it: a command line with a small local service, and three ComfyUI nodes that use that same service from the canvas.

I left the star column empty rather than inventing a figure, since the repo is new. Happy to add it if you would rather the column stayed uniform.
