### PR TITLE
Add awesome-agentic-ai prompt library

### DIFF
--- a/README.md
+++ b/README.md
@@ -443,6 +443,7 @@ Frameworks and research projects for building autonomous coding agents.
 | **Price Per Token** | Compare LLM API pricing across 200+ models. | [Website](https://pricepertoken.com/) |
 | **OpenPaw** | CLI tool (`npx pawmode`) that turns Claude Code into a personal assistant by generating system prompts (CLAUDE.md + SOUL.md) with personality, memory, and 38 skill routers. | [GitHub](https://github.com/daxaur/openpaw) |
 | **Think Better** | Open-source CLI that permanently injects 10 structured decision frameworks (MECE, Issue Trees, Pre-Mortems) and 12 cognitive bias detectors into AI assistant prompts. Go, MIT. | [GitHub](https://github.com/HoangTheQuyen/think-better) |
+| **awesome-agentic-ai** | MIT learning hub; `prompt-engineering/` slice has tested prompts for Cursor, Claude, Grok, n8n, Lovable, v0. Broader repo: skills and papers. | [GitHub](https://github.com/adriannoes/awesome-agentic-ai) |
 
 ---
 


### PR DESCRIPTION
Adds one row under **Other Notable Repositories**, near Awesome Vibe Coding and Prompt Engineering Guide.

https://github.com/adriannoes/awesome-agentic-ai

Most relevant slice for this list: `prompt-engineering/` (copy-paste prompts for Cursor, Claude, Grok, n8n, Lovable, v0). The rest is agent skills and learning material — I kept the description focused on the prompt angle.

MIT. One row.