### PR TITLE
Add prompt-portability to Prompt Management and Testing

### DIFF
--- a/README.md
+++ b/README.md
@@ -257,6 +257,7 @@ These papers established the core concepts that modern prompt engineering builds
 | **PromptInject** | Framework for quantitative analysis of LLM robustness to adversarial prompt attacks. | [GitHub](https://github.com/agencyenterprise/PromptInject) |
 | **LynxPrompt** | Self-hostable platform for managing AI IDE config files (.cursorrules, CLAUDE.md, copilot-instructions.md). Web UI, REST API, CLI, and federated blueprint marketplace for 30+ AI coding assistants. | [GitHub](https://github.com/GeiserX/LynxPrompt) |
 | **flompt** | Visual AI prompt builder that decomposes prompts into 12 semantic blocks (role, context, constraints, examples, etc.) and compiles them into optimized XML. Browser extension for ChatGPT/Claude/Gemini, and MCP server for Claude Code agents. Free, open-source. | [Website](https://flompt.dev) |
+| **prompt-portability** | Open-source CLI that lints and auto-fixes LLM prompt/request payloads (OpenAI, Anthropic, Gemini) for cross-provider portability issues -- hardcoded provider assumptions, unsupported roles, special tokens, and more. | [GitHub](https://github.com/nac7/prompt-portability) |
 
 ### LLM Evaluation Tools
 


### PR DESCRIPTION
prompt-portability is an open-source CLI that lints and auto-fixes LLM prompt/request payloads for cross-provider portability -- catching hardcoded provider assumptions, unsupported message roles, special-token leakage, and stop-sequence/temperature mismatches when moving a prompt between OpenAI, Anthropic, and Gemini.

Repo: https://github.com/nac7/prompt-portability
PyPI: https://pypi.org/project/prompt-portability/